### PR TITLE
Added support for creating ECC asymmetric keys

### DIFF
--- a/src/asymmetric_encryption.cpp
+++ b/src/asymmetric_encryption.cpp
@@ -82,6 +82,10 @@ std::vector<uint8_t> AsymmetricEncryption::encrypt(AsymmetricPublicKey key,
     SSL_RSA_ENCRYPTION_DATA_Ptr encryptedMessage{nullptr};
     size_t encryptedMessageLen{0};
 
+    if(key.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw mococrw::MoCOCrWException("Asymmetric encryption only supports RSA keys");
+    }
+
     try {
         const auto paddingMode = pad.getPadding();
         if (paddingMode != RSAPaddingMode::PKCS1  &&
@@ -139,6 +143,10 @@ AsymmetricEncryption::CryptoData AsymmetricEncryption::decrypt(AsymmetricPrivate
 {
     size_t decryptedMessageLen{0};
     SSL_RSA_ENCRYPTION_DATA_Ptr decryptedMessage{nullptr};
+
+    if (key.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Asymmetric decryption is only supported for RSA Keys");
+    }
 
     try {
         const auto paddingMode = pad.getPadding();

--- a/src/asymmetric_encryption.cpp
+++ b/src/asymmetric_encryption.cpp
@@ -100,6 +100,11 @@ std::vector<uint8_t> AsymmetricEncryption::encrypt(AsymmetricPublicKey key,
         }
 
         int maxSize{pad.getDataMaxSize(key)};
+        /* Validate message size when not using padding*/
+        if (pad.getPadding() == RSAPaddingMode::NONE &&
+            maxSize != static_cast<int>(message.toByteArray().size())){
+            throw MoCOCrWException("Message size is different from the key size");
+        }
         /* Validate message size */
         if (static_cast<int>(message.toByteArray().size()) > maxSize) {
             throw MoCOCrWException("Message too long for RSA key size");

--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -49,6 +49,12 @@ X509Certificate CertificateAuthority::createRootCertificate(const AsymmetricKeyp
                                           const CertificateSigningParameters &signParams)
 {
     auto basicConstraints = signParams.extension<BasicConstraintsExtension>();
+
+    /* Temporary guard, ECC support will be added in the near future*/
+    if (privateKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("CA creation is only supported with RSA keys");
+    }
+
     if (basicConstraints == nullptr) {
         throw MoCOCrWException("Signing parameters for a CA must include X509v3 basic extension");
     }

--- a/src/csr.cpp
+++ b/src/csr.cpp
@@ -29,6 +29,11 @@ CertificateSigningRequest::CertificateSigningRequest(const DistinguishedName &dn
                                                      const AsymmetricKeypair &keypair)
         : _req{openssl::_X509_REQ_new()}
 {
+    /* Temporary guard, ECC support will be added in the near future*/
+    if(keypair.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("CSR is only supported using RSA keys");
+    }
+
     /* setup x509 version number */
     _X509_REQ_set_version(_req.get(), 0L);
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -35,6 +35,11 @@ AsymmetricKeypair AsymmetricKeypair::generate()
     return generate(defaultSpec);
 }
 
+AsymmetricKeypair AsymmetricKeypair::generateRSA()
+{
+    return generate(RSASpec{});
+}
+
 AsymmetricKeypair AsymmetricKeypair::generateECC()
 {
     ECCSpec defaultSpec{};

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -105,6 +105,8 @@ AsymmetricKey ECCSpec::generate() const {
         _EVP_PKEY_paramgen_init(paramCtx.get());
         _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(paramCtx.get(),
                static_cast<typename std::underlying_type<openssl::ellipticCurveNid>::type>(_curveNid));
+        /*Set the curve ans1 flag so that we can save the key to a PEM format and reuse it later*/
+        _EVP_PKEY_CTX_set_ec_param_enc(paramCtx.get(), OPENSSL_EC_NAMED_CURVE);
         auto params = _EVP_PKEY_paramgen(paramCtx.get());
 
         /*Key Generation*/

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -122,10 +122,16 @@ AsymmetricKey ECCSpec::generate() const {
 
 openssl::ellipticCurveNid  AsymmetricKey::getCurve() const
 {
+    openssl::ellipticCurveNid keyNid;
     if(getType() != KeyTypes::ECC){
         throw MoCOCrWException("Functionality only supported for ECC keys");
     }
-    const EC_GROUP *group = _EC_KEY_get0_group(_key->pkey.ec);
-    return static_cast<openssl::ellipticCurveNid>(_EC_GROUP_get_curve_name(group));
+    try{
+        const EC_GROUP *group = _EC_KEY_get0_group(_key->pkey.ec);
+        keyNid =  static_cast<openssl::ellipticCurveNid>(_EC_GROUP_get_curve_name(group));
+    } catch (const OpenSSLException &e) {
+        throw MoCOCrWException(e.what());
+    }
+    return keyNid;
 }
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -119,4 +119,13 @@ AsymmetricKey ECCSpec::generate() const {
    }
    return AsymmetricKey{std::move(pkey)};
 }
+
+openssl::ellipticCurveNid  AsymmetricKey::getCurve() const
+{
+    if(getType() != KeyTypes::ECC){
+        throw MoCOCrWException("Functionality only supported for ECC keys");
+    }
+    const EC_GROUP *group = _EC_KEY_get0_group(_key->pkey.ec);
+    return static_cast<openssl::ellipticCurveNid>(_EC_GROUP_get_curve_name(group));
+}
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -35,6 +35,12 @@ AsymmetricKeypair AsymmetricKeypair::generate()
     return generate(defaultSpec);
 }
 
+AsymmetricKeypair AsymmetricKeypair::generateECC()
+{
+    ECCSpec defaultSpec{};
+    return generate(defaultSpec);
+}
+
 AsymmetricKeypair AsymmetricKeypair::generate(const AsymmetricKey::Spec &keySpec)
 {
     return AsymmetricKeypair{keySpec.generate()};

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -37,7 +37,8 @@ AsymmetricKeypair AsymmetricKeypair::generate()
 
 AsymmetricKeypair AsymmetricKeypair::generateRSA()
 {
-    return generate(RSASpec{});
+    RSASpec defaultSpec{};
+    return generate(defaultSpec);
 }
 
 AsymmetricKeypair AsymmetricKeypair::generateECC()
@@ -109,7 +110,7 @@ AsymmetricKey ECCSpec::generate() const {
         auto paramCtx = _EVP_PKEY_CTX_new_id(EVP_PKEY_EC);
         _EVP_PKEY_paramgen_init(paramCtx.get());
         _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(paramCtx.get(),
-               static_cast<typename std::underlying_type<openssl::ellipticCurveNid>::type>(_curveNid));
+               static_cast<int>(_curveNid));
         /*Set the curve ans1 flag so that we can save the key to a PEM format and reuse it later*/
         _EVP_PKEY_CTX_set_ec_param_enc(paramCtx.get(), OPENSSL_EC_NAMED_CURVE);
         auto params = _EVP_PKEY_paramgen(paramCtx.get());

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -68,7 +68,7 @@ public:
 
     /**
      * Converts the asymmetric public key to the PKCS8 format that can be written in a PEM file.
-     * @return public keu in PKCS format
+     * @return public key in PKCS format
      * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
      */
     std::string publicKeyToPem() const;

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -149,6 +149,7 @@ public:
      * @throws This method may throw an OpenSSLException if OpenSSL
      *      indicates an error
      */
+    [[deprecated("Replaced by generateRSA for improved clarity")]]
     static AsymmetricKeypair generate();
 
     /**
@@ -161,6 +162,17 @@ public:
      *      indicates an error
      */
     static AsymmetricKeypair generate(const AsymmetricKey::Spec&);
+
+    /**
+     * Generate a RSA asymmetric keypair with default Spec.
+     *
+     * Currently, a default-spec is an RSASpec with 2048
+     * bit modulus. (@see RSASpec)
+     *
+     * @throws This method may throw an OpenSSLException if OpenSSL
+     *      indicates an error
+     */
+    static AsymmetricKeypair generateRSA();
 
     /**
      * Generate an ECC asymmetric keypair with default Spec.

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -40,6 +40,9 @@ public:
     {
     }
 
+    /**
+     * Supported asymmetric key types.
+     */
     enum class KeyTypes : int { RSA = EVP_PKEY_RSA, ECC = EVP_PKEY_EC };
 
     KeyTypes getType() const  { return static_cast<KeyTypes>(openssl::_EVP_PKEY_type(_key.get())); }
@@ -63,11 +66,34 @@ public:
     {
     }
 
+    /**
+     * Converts the asymmetric public key to the PKCS8 format that can be written in a PEM file.
+     * @return public keu in PKCS format
+     * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
+     */
     std::string publicKeyToPem() const;
+    /**
+     * Reads an asymmetric public key from a PEM string and creates an @ref AsymmetricPublicKey
+     * object. Can be considered a factory method for the class.
+     * @param pem string to be read.
+     * @return the AsymmetricPublicKey object created form the PEM string
+     * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
+     */
     static AsymmetricPublicKey readPublicKeyFromPEM(const std::string& pem);
 
+    /**
+     * Getters for the internal openSSL object.
+     */
     inline EVP_PKEY* internal() { return _key.internal().get(); }
     inline const EVP_PKEY* internal() const { return _key.internal().get(); }
+
+    /**
+     * Gets the type of the asymmetric key or key pair, @see AsymmetricKey::KeyTypes for the
+     * supported types.
+     * @return the type of the asymmetric key.
+     * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
+     */
+    AsymmetricKey::KeyTypes getType() const  { return _key.getType(); }
 
     inline bool operator==(const AsymmetricPublicKey &rhs) const
     {

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -103,6 +103,12 @@ public:
      */
     openssl::ellipticCurveNid getCurve() const  { return _key.getCurve(); }
 
+    /**
+     * Gets the size of the Asymmetric key in bytes
+     * @return the size of the key in bytes
+     */
+    int getKeySize() const { return EVP_PKEY_bits(_key.internal().get());}
+
     inline bool operator==(const AsymmetricPublicKey &rhs) const
     {
         return openssl::_EVP_PKEY_cmp(internal(), rhs.internal());

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -133,7 +133,7 @@ public:
     }
 
     /**
-     * Generate an asymmetric keypair with default Spec.
+     * Generate a RSA asymmetric keypair with default Spec.
      *
      * Currently, a default-spec is an RSASpec with 2048
      * bit modulus. (@see RSASpec)
@@ -153,6 +153,17 @@ public:
      *      indicates an error
      */
     static AsymmetricKeypair generate(const AsymmetricKey::Spec&);
+
+    /**
+     * Generate an ECC asymmetric keypair with default Spec.
+     *
+     * Currently, a default-spec is an ECCspec with a PRIME_256v1 curve
+     * (aka NIST P-256 or secp256r1).
+     *
+     * @throws This method may throw an OpenSSLException if OpenSSL
+     *      indicates an error
+     */
+    static AsymmetricKeypair generateECC();
 
     /**
      * Serialize the asymmetric keypair encrypted with the given password.
@@ -193,15 +204,20 @@ public:
      *
      * Implementations should override this method
      * to encapsulate the specifics of how to generate
-     * the various types of keys (RSA, DSA, DH).
+     * the various types of keys (RSA and ECC).
      *
      */
     virtual AsymmetricKey generate() const = 0;
 };
-
+/**
+ * RSA specification used to hold the necessary parameters to generate a RSA key pair.
+ */
 class RSASpec final : public AsymmetricKey::Spec
 {
 public:
+    /**
+     * Default RSA key size in case none is specified by the used
+     */
     static constexpr unsigned int defaultSize = 2048;
     explicit RSASpec(unsigned int numBits) : _numBits{numBits} {}
     RSASpec() : RSASpec{defaultSize} {}
@@ -211,9 +227,15 @@ private:
     unsigned int _numBits;
 };
 
+/**
+ * ECC specification used to hold the necessary parameters to generate a ECC key pair.
+ */
 class ECCSpec final : public AsymmetricKey::Spec
 {
 public:
+    /**
+     * Default elliptic curve to be used in case none is specified by the user.
+     */
     static constexpr openssl::ellipticCurveNid defaultCurveNid = openssl::ellipticCurveNid::PRIME_256v1;
     explicit ECCSpec(openssl::ellipticCurveNid curveNid) : _curveNid{curveNid} {}
     ECCSpec() : ECCSpec{defaultCurveNid} {}

--- a/src/mococrw/key.h
+++ b/src/mococrw/key.h
@@ -46,7 +46,7 @@ public:
     enum class KeyTypes : int { RSA = EVP_PKEY_RSA, ECC = EVP_PKEY_EC };
 
     KeyTypes getType() const  { return static_cast<KeyTypes>(openssl::_EVP_PKEY_type(_key.get())); }
-
+    openssl::ellipticCurveNid getCurve() const;
     inline const openssl::SSL_EVP_PKEY_SharedPtr& internal() const { return _key; }
     inline openssl::SSL_EVP_PKEY_SharedPtr& internal() { return _key; }
 private:
@@ -94,6 +94,14 @@ public:
      * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
      */
     AsymmetricKey::KeyTypes getType() const  { return _key.getType(); }
+
+    /**
+     * Gets the NID of the curve that was used to generate the EC key.
+     *
+     * @return the NID of the elliptic curve used to generate the key
+     * @throws This method may throw an OpenSSLException if OpenSSL indicates an error
+     */
+    openssl::ellipticCurveNid getCurve() const  { return _key.getCurve(); }
 
     inline bool operator==(const AsymmetricPublicKey &rhs) const
     {

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -129,6 +129,7 @@ public:
     static const EC_GROUP *SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept;
     static int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept;
     static int SSL_EVP_PKEY_type(int type) noexcept;
+    static int SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept;
 
     /* Reference counting magic */
     static int SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept;

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -125,6 +125,7 @@ public:
     static int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept;
     static int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept;
     static int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept;
     static int SSL_EVP_PKEY_type(int type) noexcept;
 
     /* Reference counting magic */

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -126,6 +126,8 @@ public:
     static int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept;
     static int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept;
     static int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept;
+    static const EC_GROUP *SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept;
+    static int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept;
     static int SSL_EVP_PKEY_type(int type) noexcept;
 
     /* Reference counting magic */

--- a/src/mococrw/openssl_lib.h
+++ b/src/mococrw/openssl_lib.h
@@ -33,6 +33,7 @@ extern "C" {
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include <openssl/ec.h>
 }
 
 namespace mococrw
@@ -121,6 +122,10 @@ public:
     static void SSL_EVP_PKEY_CTX_free(EVP_PKEY_CTX* ptr) noexcept;
     static int SSL_EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits) noexcept;
     static int SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept;
+    static int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept;
+    static int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept;
+    static int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept;
+    static int SSL_EVP_PKEY_type(int type) noexcept;
 
     /* Reference counting magic */
     static int SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept;

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -307,6 +307,14 @@ int _EC_GROUP_get_curve_name(const EC_GROUP *group);
  */
 int _EVP_PKEY_type(const EVP_PKEY* key);
 
+/**
+ * Gets the size in bytes of a pkey object
+ * @param pkey key to get size from
+ * @return the size of provided key
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+int _EVP_PKEY_size(EVP_PKEY *pkey);
+
 /*
  * Thread safe modification of OpenSSL object reference counters.
  *

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -254,6 +254,39 @@ void _EVP_PKEY_keygen_init(EVP_PKEY_CTX* ctx);
  */
 void _EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits);
 
+/**
+ * Initializes the key context so we can set the appropriate parameters for the key generation
+ * @param ctx [out] initialized context
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+void _EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx);
+
+/**
+ * Generates the parameters to be used on the key generation.
+ * @param ctx context for parameter generation
+ * @return the generated parameters to be used on the key generation
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx);
+
+ /**
+  * Set the the elliptic curve used to generate the key pair
+  *
+  * @param ctx [out] pkey context created to generate the the key.
+  * @param nid [in] Identifier of the curve to be used.
+  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+  */
+void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
+
+/**
+ * Gets the type of a give PKey oject.
+ *
+ * @param key to retrieve the type from
+ * @return Returns the PKEY type being used
+ * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+ */
+int _EVP_PKEY_type(const EVP_PKEY* key);
+
 /*
  * Thread safe modification of OpenSSL object reference counters.
  *
@@ -1082,6 +1115,23 @@ int _EVP_MD_size(const EVP_MD *md);
 void* _OPENSSL_malloc(int num);
 
 void _CRYPTO_malloc_init();
+
+enum class ellipticCurveNid
+{
+    PRIME_192v1 = NID_X9_62_prime192v1,
+    PRIME_256v1 = NID_X9_62_prime256v1,
+
+    SECP_224r1 = NID_secp224r1,
+    SECP_384r1 = NID_secp384r1,
+    SECP_521r1 = NID_secp521r1,
+
+    SECT_283k1 = NID_sect283k1,
+    SECT_283r1 = NID_sect283r1,
+    SECT_409k1 = NID_sect409k1,
+    SECT_409r1 = NID_sect409r1,
+    SECT_571k1 = NID_sect571k1,
+    SECT_571r1 = NID_sect571r1,
+};
 
 }  //::openssl
 }  //::mococrw

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -272,11 +272,21 @@ SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx);
  /**
   * Set the the elliptic curve used to generate the key pair
   *
-  * @param ctx [out] pkey context created to generate the the key.
+  * @param ctx [in, out] pkey context created to generate the the key.
   * @param nid [in] Identifier of the curve to be used.
   * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
   */
 void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
+
+ /**
+  * Sets the the elliptic curve parameter encoding when generating
+  * EC parameters or an EC key
+  *
+  * @param ctx [in, out] pkey EC parameter or key context
+  * @param param_enc [in] Type of parameter encoding to be used
+  * @throw OpenSSLException if an error occurs in the underlying OpenSSL function.
+  */
+void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc);
 
 /**
  * Gets the type of a give PKey oject.

--- a/src/mococrw/openssl_wrap.h
+++ b/src/mococrw/openssl_wrap.h
@@ -289,6 +289,16 @@ void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid);
 void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc);
 
 /**
+ * Gets the EC group of a given EC key
+ */
+const EC_GROUP* _EC_KEY_get0_group(const EC_KEY *key);
+
+/**
+ * Gets the NID of the elliptic curve used to generate the EC key.
+ */
+int _EC_GROUP_get_curve_name(const EC_GROUP *group);
+
+/**
  * Gets the type of a give PKey oject.
  *
  * @param key to retrieve the type from

--- a/src/mococrw/padding_mode.h
+++ b/src/mococrw/padding_mode.h
@@ -47,7 +47,7 @@ public:
      * @param key RSA public key that will be used for encryption
      * @return the maximum size of the data that can be encrypted in bytes.
      */
-    virtual int getDataMaxSize(const AsymmetricPublicKey& key) const = 0;
+    virtual int getDataMaxSize(AsymmetricPublicKey& key) const = 0;
 
 };
 
@@ -78,12 +78,9 @@ public:
     * @param key RSA public key that will be used for encryption
     * @return the maximum size of the data that can be encrypted in bytes.
     */
-    int getDataMaxSize(const AsymmetricPublicKey& key) const override
+    int getDataMaxSize(AsymmetricPublicKey& key) const override
     {
-        if(key.getType() != AsymmetricKey::KeyTypes::RSA){
-            throw  MoCOCrWException("Functionality only supported for RSA keys");
-        }
-        return openssl::_RSA_size(key.internal()->pkey.rsa);
+        return key.getKeySize()/8;
     }
 };
 
@@ -133,12 +130,9 @@ public:
      * @param key RSA public key that will be used for encryption
      * @return the maximum size of the data that can be encrypted in bytes.
      */
-    int getDataMaxSize(const AsymmetricPublicKey& key) const override
+    int getDataMaxSize(AsymmetricPublicKey& key) const override
     {
-        if(key.getType() != AsymmetricKey::KeyTypes::RSA){
-            throw  MoCOCrWException("Functionality only supported for RSA keys");
-        }
-        return openssl::_RSA_size(key.internal()->pkey.rsa) - c_pkcsMaxSizeSOverhead;
+        return key.getKeySize()/8 - c_pkcsMaxSizeSOverhead;
     }
 
 private:
@@ -231,7 +225,7 @@ private:
      * @param Unused
      * @return -1.
      */
-    int getDataMaxSize(const AsymmetricPublicKey& key) const override
+    int getDataMaxSize(AsymmetricPublicKey& key) const override
     {
         /*Ignore unused parameter*/
         std::ignore = key;
@@ -267,7 +261,7 @@ private:
  * - Hashing function
  * - Masking function
  * - Label
- * 
+ *
  * @warning: Because of the currently used implementation of OpenSSL (1.0.2), the label size should
  *           be limited to maximum positive value of an integer (INT_MAX). This is a known bug that
  *           was fixed in OpenSSL v1.1
@@ -340,13 +334,10 @@ public:
      * @param key RSA public key that will be used for encryption
      * @return the maximum size of the data that can be encrypted in bytes.
      */
-    int getDataMaxSize(const AsymmetricPublicKey& key) const override
+    int getDataMaxSize(AsymmetricPublicKey& key) const override
     {
-        if(key.getType() != AsymmetricKey::KeyTypes::RSA){
-            throw  MoCOCrWException("Functionality only supported for RSA keys");
-        }
-        return openssl::_RSA_size(key.internal()->pkey.rsa) -
-                (2 * openssl::_EVP_MD_size(_getMDPtrFromDigestType(_hashingFunction)) - 2);
+        return key.getKeySize()/8 -
+                (2 * openssl::_EVP_MD_size(_getMDPtrFromDigestType(_hashingFunction))) - 2;
     }
 
 private:

--- a/src/mococrw/padding_mode.h
+++ b/src/mococrw/padding_mode.h
@@ -21,6 +21,7 @@
 #include <openssl/evp.h>
 #include "key.h"
 #include "openssl_wrap.h"
+#include "error.h"
 
 namespace mococrw {
 /**
@@ -79,6 +80,9 @@ public:
     */
     int getDataMaxSize(const AsymmetricPublicKey& key) const override
     {
+        if(key.getType() != AsymmetricKey::KeyTypes::RSA){
+            throw  MoCOCrWException("Functionality only supported for RSA keys");
+        }
         return openssl::_RSA_size(key.internal()->pkey.rsa);
     }
 };
@@ -131,6 +135,9 @@ public:
      */
     int getDataMaxSize(const AsymmetricPublicKey& key) const override
     {
+        if(key.getType() != AsymmetricKey::KeyTypes::RSA){
+            throw  MoCOCrWException("Functionality only supported for RSA keys");
+        }
         return openssl::_RSA_size(key.internal()->pkey.rsa) - c_pkcsMaxSizeSOverhead;
     }
 
@@ -335,6 +342,9 @@ public:
      */
     int getDataMaxSize(const AsymmetricPublicKey& key) const override
     {
+        if(key.getType() != AsymmetricKey::KeyTypes::RSA){
+            throw  MoCOCrWException("Functionality only supported for RSA keys");
+        }
         return openssl::_RSA_size(key.internal()->pkey.rsa) -
                 (2 * openssl::_EVP_MD_size(_getMDPtrFromDigestType(_hashingFunction)) - 2);
     }

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -108,6 +108,26 @@ int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept
     return EVP_PKEY_cmp(a,b);
 }
 
+int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept
+{
+    return EVP_PKEY_paramgen_init(ctx);
+}
+int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
+{
+    return EVP_PKEY_paramgen(ctx, ppkey);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept
+{
+    return EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
+{
+    return EVP_PKEY_type(type);
+}
+
+
 /* Reference counting magic */
 int OpenSSLLib::SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept {
     return CRYPTO_add(pointer, amount, type);

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -142,6 +142,10 @@ int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
     return EVP_PKEY_type(type);
 }
 
+int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept
+{
+    return EVP_PKEY_size(pkey);
+}
 
 /* Reference counting magic */
 int OpenSSLLib::SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept {

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -127,6 +127,16 @@ int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_e
     return EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
 }
 
+const EC_GROUP* OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept
+{
+    return EC_KEY_get0_group(key);
+}
+
+int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept
+{
+    return EC_GROUP_get_curve_name(group);
+}
+
 int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
 {
     return EVP_PKEY_type(type);

--- a/src/openssl_lib.cpp
+++ b/src/openssl_lib.cpp
@@ -122,6 +122,11 @@ int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, in
     return EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid);
 }
 
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept
+{
+    return EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
+}
+
 int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
 {
     return EVP_PKEY_type(type);

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -248,6 +248,11 @@ int _EVP_PKEY_type(const EVP_PKEY* key)
     return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_type, key->type);
 }
 
+int _EVP_PKEY_size(EVP_PKEY *pkey)
+{
+    return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_size, pkey);
+}
+
 bool _EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     int result = lib::OpenSSLLib::SSL_EVP_PKEY_cmp(a,b);

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -202,6 +202,36 @@ void _EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int mbits)
     OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_set_rsa_keygen_bits, ctx, mbits);
 }
 
+void _EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx)
+{
+    OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_paramgen_init, ctx);
+}
+
+SSL_EVP_PKEY_Ptr _EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx)
+{
+    EVP_PKEY* ptr{nullptr};
+    try {
+        OpensslCallIsOne::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_paramgen, ctx, &ptr);
+    } catch (const OpenSSLException& e) {
+        if (ptr) {
+            lib::OpenSSLLib::SSL_EVP_PKEY_free(ptr);
+        }
+        throw e;
+    }
+    return SSL_EVP_PKEY_Ptr{ptr};
+}
+
+void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid)
+{
+    OpensslCallIsNonNegative::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid,
+                                          ctx, nid);
+}
+
+int _EVP_PKEY_type(const EVP_PKEY* key)
+{
+    return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_type, key->type);
+}
+
 bool _EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
     int result = lib::OpenSSLLib::SSL_EVP_PKEY_cmp(a,b);

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -233,6 +233,16 @@ void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc)
                                           ctx, param_enc);
 }
 
+const EC_GROUP* _EC_KEY_get0_group(const EC_KEY *key)
+{
+    return lib::OpenSSLLib::SSL_EC_KEY_get0_group(key);
+}
+
+int _EC_GROUP_get_curve_name(const EC_GROUP *group)
+{
+    return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EC_GROUP_get_curve_name, group);
+}
+
 int _EVP_PKEY_type(const EVP_PKEY* key)
 {
     return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_type, key->type);

--- a/src/openssl_wrap.cpp
+++ b/src/openssl_wrap.cpp
@@ -227,6 +227,12 @@ void _EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid)
                                           ctx, nid);
 }
 
+void _EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc)
+{
+    OpensslCallIsNonNegative::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc,
+                                          ctx, param_enc);
+}
+
 int _EVP_PKEY_type(const EVP_PKEY* key)
 {
     return OpensslCallIsPositive::callChecked(lib::OpenSSLLib::SSL_EVP_PKEY_type, key->type);

--- a/src/signature.cpp
+++ b/src/signature.cpp
@@ -32,6 +32,10 @@ std::vector<uint8_t> SignatureUtils::create(AsymmetricPrivateKey &privateKey,
 {
     std::vector<uint8_t> messageDigest;
 
+    if(privateKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
+
     try {
         messageDigest = digestMessage(message, getHashing(padding));
     }
@@ -50,6 +54,10 @@ std::vector<uint8_t> SignatureUtils::create(AsymmetricPrivateKey &privateKey,
     const auto keyCtx = _EVP_PKEY_CTX_new(privateKey.internal());
     std::unique_ptr<unsigned char, SSLFree<unsigned char>> sig;
     size_t siglen;
+
+    if(privateKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
 
     try {
         if (!keyCtx.get()) {
@@ -87,6 +95,10 @@ void SignatureUtils::verify(AsymmetricPublicKey &publicKey,
 {
     std::vector<uint8_t> messageDigest;
 
+    if(publicKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
+
     try {
         messageDigest = digestMessage(message, getHashing(padding));
         verify(publicKey, padding, signature, messageDigest);
@@ -102,6 +114,10 @@ void SignatureUtils::verify(AsymmetricPublicKey &publicKey,
                             const std::vector<uint8_t> messageDigest)
 {
     const auto keyCtx = _EVP_PKEY_CTX_new(publicKey.internal());
+
+    if(publicKey.getType() != AsymmetricKey::KeyTypes::RSA){
+        throw MoCOCrWException("Functionality is only supported for RSA keys");
+    }
 
     try {
         _EVP_PKEY_verify_init(keyCtx.get());

--- a/tests/sdk/main.cpp
+++ b/tests/sdk/main.cpp
@@ -67,7 +67,7 @@ int main(int, char **)
                       .stateOrProvinceName("nebenan")
                       .serialNumber("08E36DD501941432358AFE8256BC6EFD")
                       .build();
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{dn, keypair};
     auto pemString = csr.toPem();
     auto publicKey = csr.getPublicKey();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -16,14 +16,13 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
         endif()
     endif()
 
-    #TODO: clean this up
     set(LIB_SOURCES "${SRC_DIR}/openssl_wrap.cpp" "${SRC_DIR}/bio.cpp" "${SRC_DIR}/distinguished_name.cpp")
     set(MOCK_SOURCES "openssl_lib_mock.cpp" ${LIB_SOURCES})
     set(REAL_SOURCES "${SRC_DIR}/openssl_lib.cpp" ${LIB_SOURCES})
 
     find_package(Threads)
 
-    #add_executable(openssltest test_opensslwrapper.cpp ${MOCK_SOURCES})
+    add_executable(openssltest test_opensslwrapper.cpp ${MOCK_SOURCES})
 
     add_executable(asn1timetests test_asn1time.cpp ${REAL_SOURCES})
     add_executable(keytests test_key.cpp ${REAL_SOURCES})
@@ -95,7 +94,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
                             "${SRC_DIR}/util.cpp"
                             ${REAL_SOURCES})
 
-    #target_link_libraries(openssltest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(openssltest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
     target_link_libraries(asn1timetests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
     target_link_libraries(keytests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
@@ -112,7 +111,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     target_link_libraries(asymencryptiontests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
     target_link_libraries(cryptodatatests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
 
-    #add_test(OpenSSLTest openssltest)
+    add_test(OpenSSLTest openssltest)
 
     add_test(Asn1TimeTests asn1timetests)
     add_test(HashTests hashtests)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -23,7 +23,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
 
     find_package(Threads)
 
-    add_executable(openssltest test_opensslwrapper.cpp ${MOCK_SOURCES})
+    #add_executable(openssltest test_opensslwrapper.cpp ${MOCK_SOURCES})
 
     add_executable(asn1timetests test_asn1time.cpp ${REAL_SOURCES})
     add_executable(keytests test_key.cpp ${REAL_SOURCES})
@@ -95,7 +95,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
                             "${SRC_DIR}/util.cpp"
                             ${REAL_SOURCES})
 
-    target_link_libraries(openssltest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    #target_link_libraries(openssltest ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
     target_link_libraries(asn1timetests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
     target_link_libraries(keytests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
@@ -112,7 +112,7 @@ if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     target_link_libraries(asymencryptiontests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
     target_link_libraries(cryptodatatests ${GMOCK_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_LIBRARIES})
 
-    add_test(OpenSSLTest openssltest)
+    #add_test(OpenSSLTest openssltest)
 
     add_test(Asn1TimeTests asn1timetests)
     add_test(HashTests hashtests)

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -192,6 +192,11 @@ int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_type(type);
 }
 
+int OpenSSLLib::SSL_EVP_PKEY_size(EVP_PKEY *pkey) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_size(pkey);
+}
+
 /* Reference counting magic */
 int OpenSSLLib::SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept {
     return OpenSSLLibMockManager::getMockInterface().SSL_CRYPTO_add(pointer, amount, type);

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -177,6 +177,16 @@ int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_e
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
 }
 
+const EC_GROUP* OpenSSLLib::SSL_EC_KEY_get0_group(const EC_KEY *key) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EC_KEY_get0_group(key);
+}
+
+int OpenSSLLib::SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EC_GROUP_get_curve_name(group);
+}
+
 int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
 {
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_type(type);

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -156,6 +156,32 @@ int OpenSSLLib::SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) noexcept
     return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_cmp(a,b);
 }
 
+int OpenSSLLib::SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_paramgen_init(ctx);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_paramgen(ctx, ppkey);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx,
+                                                                                                nid);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_CTX_set_ec_param_enc(ctx, param_enc);
+}
+
+int OpenSSLLib::SSL_EVP_PKEY_type(int type) noexcept
+{
+    return OpenSSLLibMockManager::getMockInterface().SSL_EVP_PKEY_type(type);
+}
+
 /* Reference counting magic */
 int OpenSSLLib::SSL_CRYPTO_add(int *pointer, int amount, int type) noexcept {
     return OpenSSLLibMockManager::getMockInterface().SSL_CRYPTO_add(pointer, amount, type);

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -112,6 +112,7 @@ public:
     virtual const EC_GROUP* SSL_EC_KEY_get0_group(const EC_KEY *key) = 0;
     virtual int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) = 0;
     virtual int SSL_EVP_PKEY_type(int type) = 0;
+    virtual int SSL_EVP_PKEY_size(EVP_PKEY *pkey) = 0;
 
     /* Reference counting magic */
     virtual int SSL_CRYPTO_add(int *pointer, int amount, int type) = 0;
@@ -355,6 +356,7 @@ public:
     MOCK_METHOD1(SSL_EC_GROUP_get_curve_name, int(const EC_GROUP *group));
 
     MOCK_METHOD1(SSL_EVP_PKEY_type, int(int type));
+    MOCK_METHOD1(SSL_EVP_PKEY_size, int(EVP_PKEY *pkey));
 
     MOCK_METHOD3(SSL_CRYPTO_add, int(int*, int, int));
 
@@ -471,6 +473,7 @@ public:
     MOCK_METHOD2(SSL_EVP_PKEY_CTX_get_rsa_oaep_label, int(EVP_PKEY_CTX *ctx, unsigned char *l));
     MOCK_METHOD1(SSL_RSA_size, int(const RSA *r));
     MOCK_METHOD1(SSL_EVP_MD_size, int(const EVP_MD *md));
+
 };
 
 /**

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -105,6 +105,12 @@ public:
 
     virtual int SSL_EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b) = 0;
 
+    virtual int SSL_EVP_PKEY_paramgen_init(EVP_PKEY_CTX *ctx) = 0;
+    virtual int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) = 0;
+    virtual int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) = 0;
+    virtual int SSL_EVP_PKEY_type(int type) = 0;
+
     /* Reference counting magic */
     virtual int SSL_CRYPTO_add(int *pointer, int amount, int type) = 0;
 
@@ -338,6 +344,12 @@ public:
     MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_rsa_keygen_bits, int(EVP_PKEY_CTX*, int));
 
     MOCK_METHOD2(SSL_EVP_PKEY_cmp, int(const EVP_PKEY*, const EVP_PKEY *));
+
+    MOCK_METHOD1(SSL_EVP_PKEY_paramgen_init, int(EVP_PKEY_CTX*));
+    MOCK_METHOD2(SSL_EVP_PKEY_paramgen, int(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid, int(EVP_PKEY_CTX *ctx, int nid));
+    MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_param_enc, int(EVP_PKEY_CTX *ctx, int param_enc));
+    MOCK_METHOD1(SSL_EVP_PKEY_type, int(int type));
 
     MOCK_METHOD3(SSL_CRYPTO_add, int(int*, int, int));
 

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -109,6 +109,8 @@ public:
     virtual int SSL_EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey) = 0;
     virtual int SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(EVP_PKEY_CTX *ctx, int nid) = 0;
     virtual int SSL_EVP_PKEY_CTX_set_ec_param_enc(EVP_PKEY_CTX *ctx, int param_enc) = 0;
+    virtual const EC_GROUP* SSL_EC_KEY_get0_group(const EC_KEY *key) = 0;
+    virtual int SSL_EC_GROUP_get_curve_name(const EC_GROUP *group) = 0;
     virtual int SSL_EVP_PKEY_type(int type) = 0;
 
     /* Reference counting magic */
@@ -349,6 +351,9 @@ public:
     MOCK_METHOD2(SSL_EVP_PKEY_paramgen, int(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey));
     MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid, int(EVP_PKEY_CTX *ctx, int nid));
     MOCK_METHOD2(SSL_EVP_PKEY_CTX_set_ec_param_enc, int(EVP_PKEY_CTX *ctx, int param_enc));
+    MOCK_METHOD1(SSL_EC_KEY_get0_group, EC_GROUP*(const EC_KEY *key));
+    MOCK_METHOD1(SSL_EC_GROUP_get_curve_name, int(const EC_GROUP *group));
+
     MOCK_METHOD1(SSL_EVP_PKEY_type, int(int type));
 
     MOCK_METHOD3(SSL_CRYPTO_add, int(int*, int, int));

--- a/tests/unit/test_asymmetric_encryption.cpp
+++ b/tests/unit/test_asymmetric_encryption.cpp
@@ -618,6 +618,7 @@ struct MessageSizeDataSet
     openssl::DigestTypes _masking;
     std::vector<uint8_t> _label;
     // expected outputs
+    std::string _exceptionText;
     bool _expectThrow;
 };
 
@@ -640,6 +641,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 1024-bit key, max message size (117)
@@ -653,6 +655,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 1024-bit key, max message size + 1 (118)
@@ -666,6 +669,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // PKCS, 2048-bit key, empty message
@@ -677,6 +681,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 2048-bit key, max message size (245)
@@ -692,6 +697,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // PKCS, 2048-bit key, max message size + 1 (246)
@@ -707,6 +713,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 1024-bit key, hashing SHA256, masking SHA256, empty message
@@ -718,6 +725,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 1024-bit key, hashing SHA256, masking SHA256, max message size (62)
@@ -730,6 +738,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 1024-bit key, hashing SHA256, masking SHA256, max message size + 1 (63)
@@ -742,6 +751,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 1024-bit key, hashing SHA512, masking SHA256, max message size (-2)
@@ -753,6 +763,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA512,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 2048-bit key, hashing SHA256, masking SHA256, empty message
@@ -764,6 +775,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 2048-bit key, hashing SHA256, masking SHA256, max message size (190)
@@ -778,6 +790,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 2048-bit key, hashing SHA256, masking SHA256, max message size + 1 (191)
@@ -792,6 +805,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // OAEP, 2048-bit key, hashing SHA512, masking SHA256, max message size (126)
@@ -805,6 +819,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA512,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // OAEP, 2048-bit key, hashing SHA512, masking SHA256, max message size + 1 (127)
@@ -818,6 +833,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA512,
         openssl::DigestTypes::SHA256,
         {},
+        "Message too long for RSA key size",
         true
     },
     // NO PADDING, 1024-bit key, max message size - 1 (127)
@@ -831,6 +847,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
     // NO PADDING, 1024-bit key, max message size (128)
@@ -844,6 +861,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // NO PADDING, 1024-bit key, max message size + 1 (129)
@@ -857,6 +875,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
     // NO PADDING, 2048-bit key, max message size - 1 (255)
@@ -873,6 +892,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
     // NO PADDING, 2048-bit key, max message size (256)
@@ -889,6 +909,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "",
         false
     },
     // NO PADDING, 2048-bit key, max message size + 1 (257)
@@ -905,6 +926,7 @@ AsymmetricEncryptionSizeTest::messageSizeDataSet
         openssl::DigestTypes::SHA256,
         openssl::DigestTypes::SHA256,
         {},
+        "Message size is different from the key size",
         true
     },
 
@@ -945,8 +967,15 @@ TEST_P(AsymmetricEncryptionSizeTest, testMessageSize)
                                                             data._masking,
                                                             data._label);
     if (data._expectThrow) {
-        EXPECT_THROW(AsymmetricEncryption::encrypt(publicKey, *(padding.get()), data._message),
-                         MoCOCrWException);
+        EXPECT_THROW({
+            try {
+                AsymmetricEncryption::encrypt(publicKey, *(padding.get()), data._message);
+            }
+            catch (const MoCOCrWException &e) {//this tests that it has the correct message
+                EXPECT_STREQ(data._exceptionText.c_str(), e.what());
+                throw;
+            }
+            }, MoCOCrWException);
     } else {
         EXPECT_NO_THROW(AsymmetricEncryption::encrypt(publicKey, *(padding.get()), data._message));
     }
@@ -954,3 +983,21 @@ TEST_P(AsymmetricEncryptionSizeTest, testMessageSize)
 
 INSTANTIATE_TEST_CASE_P(testMessageSize, AsymmetricEncryptionSizeTest,
                         testing::ValuesIn(AsymmetricEncryptionSizeTest::messageSizeDataSet));
+
+TEST_F(AsymmetricEncryptionSizeTest, testGetMessageSize)
+{
+    auto key1024 = mococrw::AsymmetricKeypair::readPublicKeyFromPEM(keyPairs1024bit._publicKey);
+    auto key2048 = mococrw::AsymmetricKeypair::readPublicKeyFromPEM(keyPairs2048bit._publicKey);
+
+    OAEPPadding oeapPad{};
+    EXPECT_EQ(oeapPad.getDataMaxSize(key1024), 62);
+    EXPECT_EQ(oeapPad.getDataMaxSize(key2048), 190);
+
+    PKCSPadding pkcsPadding{};
+    EXPECT_EQ(pkcsPadding.getDataMaxSize(key1024), 1024/8 - 11);
+    EXPECT_EQ(pkcsPadding.getDataMaxSize(key2048), 2048/8 - 11);
+
+    NoPadding noPadding{};
+    EXPECT_EQ(noPadding.getDataMaxSize(key1024), 1024/8);
+    EXPECT_EQ(noPadding.getDataMaxSize(key2048), 2048/8);
+}

--- a/tests/unit/test_asymmetric_encryption.cpp
+++ b/tests/unit/test_asymmetric_encryption.cpp
@@ -491,6 +491,7 @@ INSTANTIATE_TEST_CASE_P(testSuccessfulEncryption, AsymmetricEncryptionTest,
  *
  * The following use cases are covered:
  * - unsupported padding (PSS)
+ * - ECC Key
  */
 TEST_F(AsymmetricEncryptionTest, testEncryptionInvalidParameters)
 {
@@ -504,6 +505,12 @@ TEST_F(AsymmetricEncryptionTest, testEncryptionInvalidParameters)
                                                unsupportedPaddingMode,
                                                nominalDataSet[0]._message),
                  MoCOCrWException);
+
+    auto eccKey = AsymmetricKeypair::generateECC();
+    EXPECT_THROW(AsymmetricEncryption::encrypt(eccKey,
+                                               OAEPPadding{},
+                                               nominalDataSet[0]._message),
+                 MoCOCrWException);
 }
 
 /**
@@ -511,6 +518,7 @@ TEST_F(AsymmetricEncryptionTest, testEncryptionInvalidParameters)
  *
  * The following use cases are covered:
  * - unsupported padding (PSS)
+ * - ECC key
  */
 TEST_F(AsymmetricEncryptionTest, testDecryptionInvalidParameters)
 {
@@ -524,6 +532,12 @@ TEST_F(AsymmetricEncryptionTest, testDecryptionInvalidParameters)
 
     EXPECT_THROW(AsymmetricEncryption::decrypt(privateKey,
                                                unsupportedPaddingMode,
+                                               nominalDataSet[0]._encrypted),
+                 MoCOCrWException);
+
+    auto eccKey = AsymmetricKeypair::generateECC();
+    EXPECT_THROW(AsymmetricEncryption::decrypt(eccKey,
+                                               OAEPPadding{},
                                                nominalDataSet[0]._encrypted),
                  MoCOCrWException);
 }

--- a/tests/unit/test_ca.cpp
+++ b/tests/unit/test_ca.cpp
@@ -62,7 +62,7 @@ protected:
 
 void CATest::SetUp()
 {
-    _rootKey = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generate());
+    _rootKey = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generateRSA());
 
     _certDetails = std::make_unique<DistinguishedName>(DistinguishedName::Builder{}
                  .organizationalUnitName("Car IT")
@@ -240,7 +240,7 @@ TEST_F(CATest, testCAContents)
 
 TEST_F(CATest, testSignedCSRHasCorrectFields)
 {
-    CertificateSigningRequest csr{*_certDetails, AsymmetricKeypair::generate()};
+    CertificateSigningRequest csr{*_certDetails, AsymmetricKeypair::generateRSA()};
     X509Certificate cert = _ca->signCSR(csr);
     testValiditySpan(cert, _signParams.certificateValidity(), Asn1Time::now());
     EXPECT_EQ(csr.getPublicKey(), cert.getPublicKey());
@@ -254,36 +254,36 @@ TEST_F(CATest, testCanSignCACertificates)
     //Adjust CA to generate CA certificates
     _ca = std::make_unique<CertificateAuthority>(_caSignParams, 0, *_rootCert, *_rootKey);
 
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{*_certDetails, keypair};
     X509Certificate cert = _ca->signCSR(csr);
     CertificateAuthority newCA(_signParams, 0, cert, keypair);
-    csr = CertificateSigningRequest{*_secondaryCertDetails, AsymmetricKeypair::generate()};
+    csr = CertificateSigningRequest{*_secondaryCertDetails, AsymmetricKeypair::generateRSA()};
     X509Certificate secondaryCert = newCA.signCSR(csr);
     ASSERT_NO_THROW(secondaryCert.verify({*_rootCert}, {cert}));
 }
 
 TEST_F(CATest, testSignedNoCACertificatesCantSignOtherCertificates)
 {
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{*_certDetails, keypair};
     X509Certificate cert = _ca->signCSR(csr);
     // The newly created certificate has CA=false
     CertificateAuthority newCA(_signParams, 0, cert, keypair);
-    csr = CertificateSigningRequest{*_certDetails, AsymmetricKeypair::generate()};
+    csr = CertificateSigningRequest{*_certDetails, AsymmetricKeypair::generateRSA()};
     // The signing fails because the certificate has CA=false
     ASSERT_THROW(newCA.signCSR(csr), MoCOCrWException);
 }
 
 TEST_F(CATest, testInitializeCAWithNonMatchingKey)
 {
-    EXPECT_THROW(CertificateAuthority(_signParams, 0, *_rootCert, AsymmetricKeypair::generate()),
+    EXPECT_THROW(CertificateAuthority(_signParams, 0, *_rootCert, AsymmetricKeypair::generateRSA()),
                  MoCOCrWException);
 }
 
 TEST_F(CATest, testVerifyCAAgainstPureOpenSslOutput)
 {
-    auto keypair = AsymmetricKeypair::generate();
+    auto keypair = AsymmetricKeypair::generateRSA();
     CertificateSigningRequest csr{*_certDetails, keypair};
     X509Certificate cert = _ca->signCSR(csr);
 
@@ -327,7 +327,7 @@ TEST_F(CATest, testIssueLongLivedCertificate)
     _ca = std::make_unique<CertificateAuthority>(_signParams, 0, *_rootCert, *_rootKey);
 
     X509Certificate cert = _ca->signCSR(CertificateSigningRequest{*_certDetails,
-                                                       AsymmetricKeypair::generate()});
+                                                       AsymmetricKeypair::generateRSA()});
 
     testValiditySpan(cert, validityTime, Asn1Time::now());
 
@@ -350,7 +350,7 @@ TEST_F(CATest, DISABLED_testIssueCertificateInFarFuture)
     _ca = std::make_unique<CertificateAuthority>(_signParams, 0, *_rootCert, *_rootKey);
 
     X509Certificate cert = _ca->signCSR(CertificateSigningRequest{*_certDetails,
-                                                       AsymmetricKeypair::generate()});
+                                                       AsymmetricKeypair::generateRSA()});
 
     testValiditySpan(cert, validityTime, validFrom);
 

--- a/tests/unit/test_csr.cpp
+++ b/tests/unit/test_csr.cpp
@@ -51,7 +51,7 @@ void CSRTest::SetUp()
                                         .stateOrProvinceName("nebenan")
                                         .serialNumber("08E36DD501941432358AFE8256BC6EFD")
                                         .build());
-    _keypair = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generate());
+    _keypair = std::make_unique<AsymmetricKeypair>(AsymmetricKeypair::generateRSA());
 }
 
 void CSRTest::TearDown()

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -114,17 +114,15 @@ TEST_F(KeyHandlingTests, ecc_adoc_test)
 
 }
 
-
-
 /* Test the KeySpec and the generation of keys that way */
 
-//TEST(KeySpecTest, testGeneratingRSAKeyWithDefaultParameters)
-//{
-//    RSASpec spec{};
-//
-//    auto keypair = spec.generate();
-//    ASSERT_THAT(keypair.internal(), NotNull());
-//}
+TEST(KeySpecTest, testGeneratingRSAKeyWithDefaultParameters)
+{
+    RSASpec spec{};
+
+    auto keypair = spec.generate();
+    ASSERT_THAT(keypair.internal(), NotNull());
+}
 
 TEST(KeySpecTest, testThatDefaultParametersAreSane)
 {

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -30,8 +30,8 @@ class KeyHandlingTests : public ::testing::Test
 public:
     void SetUp() override;
 protected:
-    mococrw::AsymmetricKeypair _rsaKeyPair = AsymmetricKeypair::generate();
-    mococrw::AsymmetricKeypair _rsaKeyPair2 = AsymmetricKeypair::generate();
+    mococrw::AsymmetricKeypair _rsaKeyPair = AsymmetricKeypair::generateRSA();
+    mococrw::AsymmetricKeypair _rsaKeyPair2 = AsymmetricKeypair::generateRSA();
     mococrw::AsymmetricKeypair _eccKeyPairDefault = AsymmetricKeypair::generateECC();
     mococrw::AsymmetricKeypair _eccKeyPairDefault2 = AsymmetricKeypair::generateECC();
     mococrw::AsymmetricKeypair _eccKeyPairSect571r1 = AsymmetricKeypair::generateECC();
@@ -39,8 +39,8 @@ protected:
 };
 
 void KeyHandlingTests::SetUp() {
-    _rsaKeyPair = AsymmetricKeypair::generate();
-    _rsaKeyPair2 = AsymmetricKeypair::generate();
+    _rsaKeyPair = AsymmetricKeypair::generateRSA();
+    _rsaKeyPair2 = AsymmetricKeypair::generateRSA();
 
     _eccKeyPairDefault = AsymmetricKeypair::generateECC();
     _eccKeyPairDefault2 = AsymmetricKeypair::generateECC();

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -32,13 +32,21 @@ public:
 protected:
     mococrw::AsymmetricKeypair _rsaKeyPair = AsymmetricKeypair::generate();
     mococrw::AsymmetricKeypair _rsaKeyPair2 = AsymmetricKeypair::generate();
-    mococrw::AsymmetricKeypair _eccKeyPair = AsymmetricKeypair::generateECC();
-    mococrw::AsymmetricKeypair _eccKeyPair2 = AsymmetricKeypair::generateECC();
+    mococrw::AsymmetricKeypair _eccKeyPairDefault = AsymmetricKeypair::generateECC();
+    mococrw::AsymmetricKeypair _eccKeyPairDefault2 = AsymmetricKeypair::generateECC();
+    mococrw::AsymmetricKeypair _eccKeyPairSect571r1 = AsymmetricKeypair::generateECC();
+    mococrw::AsymmetricKeypair _eccKeyPairSecp521r1 = AsymmetricKeypair::generateECC();
 };
 
 void KeyHandlingTests::SetUp() {
     _rsaKeyPair = AsymmetricKeypair::generate();
     _rsaKeyPair2 = AsymmetricKeypair::generate();
+
+    _eccKeyPairDefault = AsymmetricKeypair::generateECC();
+    _eccKeyPairDefault2 = AsymmetricKeypair::generateECC();
+
+    _eccKeyPairSect571r1 = AsymmetricKeypair::generate(mococrw::ECCSpec{openssl::ellipticCurveNid::SECT_571r1});
+    _eccKeyPairSecp521r1 = AsymmetricKeypair::generate(mococrw::ECCSpec{openssl::ellipticCurveNid::SECP_521r1});
 }
 
 TEST_F(KeyHandlingTests, testGeneratedKeyIsNotNull)
@@ -46,8 +54,11 @@ TEST_F(KeyHandlingTests, testGeneratedKeyIsNotNull)
     ASSERT_THAT(_rsaKeyPair.internal(), NotNull());
     ASSERT_THAT(_rsaKeyPair2.internal(), NotNull());
 
-    ASSERT_THAT(_eccKeyPair.internal(), NotNull());
-    ASSERT_THAT(_eccKeyPair2.internal(), NotNull());
+    ASSERT_THAT(_eccKeyPairDefault.internal(), NotNull());
+    ASSERT_THAT(_eccKeyPairDefault2.internal(), NotNull());
+
+    ASSERT_THAT(_eccKeyPairSecp521r1.internal(), NotNull());
+    ASSERT_THAT(_eccKeyPairSect571r1.internal(), NotNull());
 
 }
 
@@ -56,44 +67,45 @@ TEST_F(KeyHandlingTests, testPublicKeyPemIsReproducible)
     const auto pemOfKey = _rsaKeyPair.publicKeyToPem();
     const auto pemOfKey2 = _rsaKeyPair.publicKeyToPem();
 
-    const auto pemOfEccKey = _eccKeyPair.publicKeyToPem();
-    const auto pemOfEccKey2 = _eccKeyPair.publicKeyToPem();
+    const auto pemOfEccKey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfEccKey2 = _eccKeyPairDefault.publicKeyToPem();
+
+    const auto pemOfSectEccKey = _eccKeyPairSect571r1.publicKeyToPem();
+    const auto pemOfSectEccKey2 = _eccKeyPairSect571r1.publicKeyToPem();
 
     ASSERT_EQ(pemOfKey, pemOfKey2);
     ASSERT_EQ(pemOfEccKey, pemOfEccKey2);
-
+    ASSERT_EQ(pemOfSectEccKey, pemOfSectEccKey2);
 }
 
 TEST_F(KeyHandlingTests, testPubKeyFromSavedPemIsSameAsOriginalInOpenSSLObject)
 {
     const auto pemOfPubkey = _rsaKeyPair.publicKeyToPem();
-
-    const auto pemOfEccPubkey = _eccKeyPair.publicKeyToPem();
+    const auto pemOfEccPubkey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfSecpEccPubkey = _eccKeyPairSecp521r1.publicKeyToPem();
 
     auto rsaParsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfPubkey);
     auto eccParsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfEccPubkey);
-
-    EXPECT_EQ(openssl::_EVP_PKEY_cmp(_eccKeyPair.internal(), eccParsedKey.internal()), true);
-
+    auto eccSecpParsedKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfSecpEccPubkey);
 
     ASSERT_EQ(_rsaKeyPair, rsaParsedKey);
-
-    ASSERT_EQ(_eccKeyPair, eccParsedKey);
-
+    ASSERT_EQ(_eccKeyPairDefault, eccParsedKey);
+    ASSERT_EQ(_eccKeyPairSecp521r1, eccSecpParsedKey);
 }
 
 TEST_F(KeyHandlingTests, testPubkeyFromSavedPemIsSameAsOriginalInPEM)
 {
     const auto pemOfKey = _rsaKeyPair.publicKeyToPem();
-    const auto pemOfEccKey = _eccKeyPair.publicKeyToPem();
-
+    const auto pemOfEccKey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfSectEccKey = _eccKeyPairSect571r1.publicKeyToPem();
 
     auto parsedRsaKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfKey);
     auto parsedEccKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfEccKey);
+    auto parsedSectEccKey = mococrw::AsymmetricPublicKey::readPublicKeyFromPEM(pemOfSectEccKey);
 
     ASSERT_EQ(pemOfKey, parsedRsaKey.publicKeyToPem());
     ASSERT_EQ(pemOfEccKey, parsedEccKey.publicKeyToPem());
-
+    ASSERT_EQ(pemOfSectEccKey, parsedSectEccKey.publicKeyToPem());
 }
 
 TEST_F(KeyHandlingTests, testPrivKeyFromSavedPemIsSameAsOriginal)
@@ -104,19 +116,24 @@ TEST_F(KeyHandlingTests, testPrivKeyFromSavedPemIsSameAsOriginal)
     auto retrievedKeyPair = AsymmetricKeypair::readPrivateKeyFromPEM(pemOfPrivateKey, "secret");
     ASSERT_EQ(pemOfPubKey, retrievedKeyPair.publicKeyToPem());
 
-    const auto pemOfEccPubKey = _eccKeyPair.publicKeyToPem();
-    const auto pemOfEccPrivateKey = _eccKeyPair.privateKeyToPem("password");
+    const auto pemOfEccPubKey = _eccKeyPairDefault.publicKeyToPem();
+    const auto pemOfEccPrivateKey = _eccKeyPairDefault.privateKeyToPem("password");
 
     auto retrievedEccKeyPair = AsymmetricKeypair::readPrivateKeyFromPEM(pemOfEccPrivateKey, "password");
     ASSERT_EQ(pemOfEccPubKey, retrievedEccKeyPair.publicKeyToPem());
 
+    const auto pemOfSectEccPubKey = _eccKeyPairSect571r1.publicKeyToPem();
+    const auto pemOfSectEccPrivateKey = _eccKeyPairSect571r1.privateKeyToPem("santa");
+
+    auto retrievedSectEccKeyPair = AsymmetricKeypair::readPrivateKeyFromPEM(pemOfSectEccPrivateKey, "santa");
+    ASSERT_EQ(pemOfSectEccPubKey, retrievedSectEccKeyPair.publicKeyToPem());
 }
 
 TEST_F(KeyHandlingTests, testBothGeneratedKeysNotTheSame)
 {
     ASSERT_NE(_rsaKeyPair, _rsaKeyPair2);
 
-    ASSERT_NE(_eccKeyPair, _eccKeyPair2);
+    ASSERT_NE(_eccKeyPairDefault, _eccKeyPairDefault2);
 }
 
 TEST_F(KeyHandlingTests, testThrowsWhenReadingPrivateKeyUsingWrongKey)
@@ -125,15 +142,34 @@ TEST_F(KeyHandlingTests, testThrowsWhenReadingPrivateKeyUsingWrongKey)
     ASSERT_THROW(AsymmetricKeypair::readPrivateKeyFromPEM(pemOfPrivateKey, "wrongkey"),
                  mococrw::OpenSSLException);
 
-    const auto pemOfEccPrivateKey = _eccKeyPair.privateKeyToPem("secret");
+    const auto pemOfEccPrivateKey = _eccKeyPairDefault.privateKeyToPem("secret");
     ASSERT_THROW(AsymmetricKeypair::readPrivateKeyFromPEM(pemOfEccPrivateKey, "wrongkey"),
+                 mococrw::OpenSSLException);
+
+    const auto pemOfSecpEccPrivateKey = _eccKeyPairSecp521r1.privateKeyToPem("secret");
+    ASSERT_THROW(AsymmetricKeypair::readPrivateKeyFromPEM(pemOfSecpEccPrivateKey, "santa"),
                  mococrw::OpenSSLException);
 }
 
 TEST_F(KeyHandlingTests, testKeyTypeChecking)
 {
-    EXPECT_EQ(_eccKeyPair.getType(), AsymmetricKey::KeyTypes::ECC);
+    EXPECT_EQ(_eccKeyPairDefault.getType(), AsymmetricKey::KeyTypes::ECC);
     EXPECT_EQ(_rsaKeyPair.getType(), AsymmetricKey::KeyTypes::RSA);
+    EXPECT_EQ(_eccKeyPairSecp521r1.getType(), AsymmetricKey::KeyTypes::ECC);
+    EXPECT_EQ(_eccKeyPairSect571r1.getType(), AsymmetricKey::KeyTypes::ECC);
+}
+
+TEST_F(KeyHandlingTests, testGetEccCurve)
+{
+    EXPECT_EQ(_eccKeyPairDefault.getCurve(), openssl::ellipticCurveNid::PRIME_256v1);
+    EXPECT_EQ(_eccKeyPairSect571r1.getCurve(), openssl::ellipticCurveNid::SECT_571r1);
+    EXPECT_EQ(_eccKeyPairSecp521r1.getCurve(), openssl::ellipticCurveNid::SECP_521r1);
+}
+
+TEST_F(KeyHandlingTests, testGetCurveWithRsaKey)
+{
+    ASSERT_THROW(_rsaKeyPair.getCurve(), mococrw::MoCOCrWException);
+    ASSERT_THROW(_rsaKeyPair2.getCurve(), mococrw::MoCOCrWException);
 }
 
 /* Test the KeySpec and the generation of keys that way */

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -172,6 +172,16 @@ TEST_F(KeyHandlingTests, testGetCurveWithRsaKey)
     ASSERT_THROW(_rsaKeyPair2.getCurve(), mococrw::MoCOCrWException);
 }
 
+TEST_F(KeyHandlingTests, testGetSize)
+{
+    EXPECT_EQ(_rsaKeyPair.getKeySize(), 2048);
+    EXPECT_EQ(_eccKeyPairDefault.getKeySize(), 256);
+    EXPECT_EQ(_eccKeyPairSecp521r1.getKeySize(), 521);
+    EXPECT_EQ(_eccKeyPairSect571r1.getKeySize(), 570);
+    auto rsaKey1024 = AsymmetricKeypair::generate(mococrw::RSASpec{1024});
+    EXPECT_EQ(rsaKey1024.getKeySize(), 1024);
+}
+
 /* Test the KeySpec and the generation of keys that way */
 TEST(KeySpecTest, testGeneratingRSAKeyWithDefaultParameters)
 {

--- a/tests/unit/test_key.cpp
+++ b/tests/unit/test_key.cpp
@@ -89,16 +89,42 @@ TEST_F(KeyHandlingTests, testThrowsWhenReadingPrivateKeyUsingWrongKey)
                  mococrw::OpenSSLException);
 }
 
+TEST_F(KeyHandlingTests, ecc_adoc_test)
+{
+    ECCSpec spec{};
+    auto key = AsymmetricKeypair::generate(spec);
+    std::cout << key.privateKeyToPem("alice") << std::endl;
+    std::cout << "-------------------------------------------------------" << std::endl;
+    std::cout << key.publicKeyToPem() << std::endl;
+
+    auto key2 = AsymmetricKeypair::generate(spec);
+    std::cout << key2.privateKeyToPem("pass") << std::endl;
+    std::cout << "-------------------------------------------------------" << std::endl;
+    std::cout << key2.publicKeyToPem() << std::endl;
+
+//    auto retrievedKey = AsymmetricKeypair::readPrivateKeyFromPEM(key.privateKeyToPem(pass), pass);
+//    std::cout << "-------------------------------------------------------" << std::endl;
+//    std::cout << retrievedKey.privateKeyToPem("password") << std::endl;
+//    std::cout << "-------------------------------------------------------" << std::endl;
+//    std::cout << retrievedKey.publicKeyToPem() << std::endl;
+//    if (retrievedKey == key)
+//        ASSERT_EQ(true, true);
+//    else
+//        ASSERT_EQ(true, false);
+
+}
+
+
 
 /* Test the KeySpec and the generation of keys that way */
 
-TEST(KeySpecTest, testGeneratingRSAKeyWithDefaultParameters)
-{
-    RSASpec spec{};
-
-    auto keypair = spec.generate();
-    ASSERT_THAT(keypair.internal(), NotNull());
-}
+//TEST(KeySpecTest, testGeneratingRSAKeyWithDefaultParameters)
+//{
+//    RSASpec spec{};
+//
+//    auto keypair = spec.generate();
+//    ASSERT_THAT(keypair.internal(), NotNull());
+//}
 
 TEST(KeySpecTest, testThatDefaultParametersAreSane)
 {

--- a/tests/unit/test_signature.cpp
+++ b/tests/unit/test_signature.cpp
@@ -64,7 +64,7 @@ protected:
 
 void SignatureTest::SetUp()
 {
-    _keyPair = std::make_unique<AsymmetricKeypair>(mococrw::AsymmetricKeypair::generate());
+    _keyPair = std::make_unique<AsymmetricKeypair>(mococrw::AsymmetricKeypair::generateRSA());
 
     _root1_pubkey = std::make_unique<AsymmetricPublicKey>(loadPubkeyFromFile("root1.pubkey.pem"));
     _root1_cert = std::make_unique<X509Certificate>(loadCertFromFile("signCertificate.pem"));


### PR DESCRIPTION
Features:
- Added support to generate ECC keys with all the OpenSSL NIST curves.
- Introduced guards to functionality that only supports RSA keys
- Extended unit tests